### PR TITLE
Raw Transactions

### DIFF
--- a/etheno/__main__.py
+++ b/etheno/__main__.py
@@ -9,7 +9,7 @@ from .differentials import DifferentialTester
 from .etheno import app, EthenoView, GETH_DEFAULT_RPC_PORT, ManticoreClient, ETHENO
 from .genesis import Account, make_accounts, make_genesis
 from .synchronization import AddressSynchronizingClient, RawTransactionClient
-from .utils import find_open_port, format_hex_address
+from .utils import decode_value, find_open_port, format_hex_address
 from . import Etheno
 from . import ganache
 from . import geth
@@ -68,7 +68,7 @@ def main(argv = None):
                 pkey = None
                 if 'privateKey' in bal:
                     pkey = bal['privateKey']
-                accounts.append(Account(address = int(addr, 16), balance = int(bal['balance']), private_key = pkey))
+                accounts.append(Account(address = int(addr, 16), balance = decode_value(bal['balance']), private_key = decode_value(pkey)))
     else:
         # We will generate it further below once we've resolved all of the parameters
         genesis = None

--- a/etheno/synchronization.py
+++ b/etheno/synchronization.py
@@ -67,7 +67,8 @@ class ChainSynchronizer(object):
         except NotImplementedError:
             pass
         new_address = self._old_create_account(balance = balance, address = None)
-        self.mapping[address] = new_address
+        if address is not None:
+            self.mapping[address] = new_address
         return new_address
 
     def post(self, data):
@@ -134,4 +135,3 @@ def AddressSynchronizingClient(etheno_client):
     setattr(etheno_client, 'post', ChainSynchronizer.post.__get__(synchronizer, ChainSynchronizer))
      
     return etheno_client
-        

--- a/etheno/synchronization.py
+++ b/etheno/synchronization.py
@@ -3,7 +3,7 @@ import time
 from web3.auto import w3
 
 from .client import EthenoClient, SelfPostingClient, jsonrpc, DATA, QUANTITY
-from .utils import decode_hex, format_hex_address
+from .utils import decode_hex, format_hex_address, int_to_bytes
 
 def _decode_value(value):
     if isinstance(value, int):
@@ -153,7 +153,7 @@ class RawTransactionSynchronizer(ChainSynchronizer):
     def create_account(self, balance = 0, address = None):
         self._account_index += 1
         new_address = self.accounts[self._account_index].address
-        self._private_keys[new_address] = int.from_bytes(self.accounts[self._account_index].private_key, byteorder='big')
+        self._private_keys[new_address] = int_to_bytes(self.accounts[self._account_index].private_key)
         if address is not None:
             self.mapping[address] = new_address
         return new_address
@@ -187,8 +187,8 @@ class RawTransactionSynchronizer(ChainSynchronizer):
         else:
             return super().post(data)
 
-def RawTransactionClient(etheno_client):
-    synchronizer = RawTransactionSynchronizer(etheno_client)
+def RawTransactionClient(etheno_client, accounts):
+    synchronizer = RawTransactionSynchronizer(etheno_client, accounts)
 
     setattr(etheno_client, 'create_account', RawTransactionSynchronizer.create_account.__get__(synchronizer, RawTransactionSynchronizer))
     setattr(etheno_client, 'post', RawTransactionSynchronizer.post.__get__(synchronizer, RawTransactionSynchronizer))

--- a/etheno/synchronization.py
+++ b/etheno/synchronization.py
@@ -1,5 +1,7 @@
 import time
 
+from web3.auto import w3
+
 from .client import EthenoClient, SelfPostingClient, jsonrpc, DATA, QUANTITY
 from .utils import decode_hex, format_hex_address
 
@@ -133,5 +135,62 @@ def AddressSynchronizingClient(etheno_client):
 
     setattr(etheno_client, 'create_account', ChainSynchronizer.create_account.__get__(synchronizer, ChainSynchronizer))
     setattr(etheno_client, 'post', ChainSynchronizer.post.__get__(synchronizer, ChainSynchronizer))
+     
+    return etheno_client
+        
+class RawTransactionSynchronizer(ChainSynchronizer):
+    def __init__(self, client, accounts):
+        super().__init__(client)
+        self.accounts = accounts
+        self._private_keys = {}
+        self._account_index = -1
+        self._chain_id = int(client.post({
+            'id': 1,
+            'jsonrpc': '2.0',
+            'method': 'net_version'
+        })['result'], 16)
+
+    def create_account(self, balance = 0, address = None):
+        self._account_index += 1
+        new_address = self.accounts[self._account_index].address
+        self._private_keys[new_address] = int.from_bytes(self.accounts[self._account_index].private_key, byteorder='big')
+        if address is not None:
+            self.mapping[address] = new_address
+        return new_address
+
+    def post(self, data):
+        method = data['method']
+
+        if method == 'eth_sendTransaction':
+            # This client does not support sendTransaction because it does not have any of the requisite accounts.
+            # So let's manually sign the transaction and send it to the client using eth_sendRawTransaction, instead.
+            from_address = int(data['from'], 16)
+            if from_address not in self._private_keys:
+                raise Exception("Error: eth_sendTransaction sent from unknown address %s:\n%s" % (data['from'], data))
+            data = dict(data)                
+            data['chainId'] = self._chain_id
+            transaction_count = int(client.post({
+                'id': 1,
+                'jsonrpc': '2.0',
+                'method': 'eth_getTransactionCount',
+                'params': [data['from'], 'latest']
+            })['result'], 16)
+            data['nonce'] = transaction_count
+            signed_txn = w3.eth.account.signTransaction(data, private_key=self._private_keys[from_address])
+            print(signed_txn.raw_transaction)
+            return super().post({
+                'id': 1,
+                'jsonrpc': '2.0',
+                'method': 'eth_sendRawTransaction',
+                'params': [signed_txn.raw_transaction]
+            })
+        else:
+            return super().post(data)
+
+def RawTransactionClient(etheno_client):
+    synchronizer = RawTransactionSynchronizer(etheno_client)
+
+    setattr(etheno_client, 'create_account', RawTransactionSynchronizer.create_account.__get__(synchronizer, RawTransactionSynchronizer))
+    setattr(etheno_client, 'post', RawTransactionSynchronizer.post.__get__(synchronizer, RawTransactionSynchronizer))
      
     return etheno_client

--- a/etheno/utils.py
+++ b/etheno/utils.py
@@ -1,6 +1,11 @@
+import math
 import socket
 from urllib.request import urlopen
 from urllib.error import HTTPError, URLError
+
+def int_to_bytes(n):
+    number_of_bytes = int(math.ceil(n.bit_length() / 8))
+    return n.to_bytes(number_of_bytes, byteorder='big')
 
 def decode_hex(data):
     if data is None:

--- a/etheno/utils.py
+++ b/etheno/utils.py
@@ -10,9 +10,19 @@ def int_to_bytes(n):
 def decode_hex(data):
     if data is None:
         return None
-    if data[:2] == '0x':
+    if data.startswith('0x'):
         data = data[2:]
     return bytes.fromhex(data)
+
+def decode_value(v):
+    if isinstance(v, int):
+        return v
+    elif v.startswith('0x') or (frozenset(['a', 'b', 'c', 'd', 'e', 'f']) & frozenset(v)):
+        # this is a hex string
+        return int(v, 16)
+    else:
+        # assume it is a regular int
+        return int(v)
 
 def format_hex_address(addr):
     if addr is None:


### PR DESCRIPTION
Support clients that do not have any accounts by automatically translating calls to `eth_sendTransaction` to signed raw transactions. See #11.