### PR TITLE
Improve manticore scripts tracebacks

### DIFF
--- a/etheno/__main__.py
+++ b/etheno/__main__.py
@@ -262,7 +262,13 @@ def main(argv = None):
 
             if manticore_client is not None:
                 if args.manticore_script is not None:
-                    exec(args.manticore_script.read(), {'manticore' : manticore_client.manticore, 'manticoreutils' : manticoreutils, 'logger' : logger.EthenoLogger(os.path.basename(args.manticore_script.name), parent=manticore_client.logger)})
+                    f = args.manticore_script
+                    code = compile(f.read(), f.name, 'exec')
+                    exec(code, {
+                        'manticore': manticore_client.manticore,
+                        'manticoreutils': manticoreutils,
+                        'logger': logger.EthenoLogger(os.path.basename(args.manticore_script.name), parent=manticore_client.logger)
+                    })
                 else:
                     manticoreutils.register_all_detectors(manticore_client.manticore)
                     manticore_client.multi_tx_analysis()


### PR DESCRIPTION
So instead of:
```
ERROR    [11-13|15:43:11][Etheno] Truffle exited with code 1
127.0.0.1 - - [13/Nov/2018 15:43:12] "GET /shutdown HTTP/1.1" 200 -
Exception in thread Thread-2:
Traceback (most recent call last):
  File "/usr/local/Cellar/python/3.7.0/Frameworks/Python.framework/Versions/3.7/lib/python3.7/threading.py", line 917, in _bootstrap_inner
    self.run()
  File "/usr/local/Cellar/python/3.7.0/Frameworks/Python.framework/Versions/3.7/lib/python3.7/threading.py", line 865, in run
    self._target(*self._args, **self._kwargs)
  File "/Users/dc/projects/etheno/etheno/__main__.py", line 265, in truffle_thread
    exec(args.manticore_script.read(), {'manticore' : manticore_client.manticore, 'manticoreutils' : manticoreutils, 'logger' : logger.EthenoLogger(os.path.basename(args.manticore_script.name), parent=manticore_client.logger)})
  File "<string>", line 10, in <module>
IndexError: list index out of range
```

that doesn't show the problem within the script, we will get:

```
ERROR    [11-13|15:44:38][Etheno] Truffle exited with code 1
127.0.0.1 - - [13/Nov/2018 15:44:38] "GET /shutdown HTTP/1.1" 200 -
Exception in thread Thread-2:
Traceback (most recent call last):
  File "/usr/local/Cellar/python/3.7.0/Frameworks/Python.framework/Versions/3.7/lib/python3.7/threading.py", line 917, in _bootstrap_inner
    self.run()
  File "/usr/local/Cellar/python/3.7.0/Frameworks/Python.framework/Versions/3.7/lib/python3.7/threading.py", line 865, in run
    self._target(*self._args, **self._kwargs)
  File "/Users/dc/projects/etheno/etheno/__main__.py", line 270, in truffle_thread
    'logger': logger.EthenoLogger(os.path.basename(args.manticore_script.name), parent=manticore_client.logger)
  File "etheno_scripts/main.py", line 10, in <module>
    contract_account = list(manticore.contract_accounts.values())[2]
IndexError: list index out of range
```